### PR TITLE
Use closest turbo frame with src attribute per default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /node_modules
 Gemfile.lock
 *.key
+*~

--- a/app/javascript/drivers/index.js
+++ b/app/javascript/drivers/index.js
@@ -12,7 +12,8 @@ function src (element, frame) {
 }
 
 function find (element) {
-  let frame = elements.findClosestFrame(element)
+  let frame = elements.findClosestFrameWithSource(element)
+
   const { turboFrame, turboMethod } = element.dataset
 
   if (element.tagName.toLowerCase() === 'form')

--- a/app/javascript/elements.js
+++ b/app/javascript/elements.js
@@ -5,9 +5,12 @@ function findClosestCommand (element) {
   return element.closest(`[${schema.commandAttribute}]`)
 }
 
-// TODO: update this method to findClosestFrameWithSource (`src` or `turbo-boost-src`)
-function findClosestFrame (element) {
-  return element.closest('turbo-frame')
+function findClosestFrameWithSource (element) {
+  return (
+    element.closest('turbo-frame[src]') ||
+    element.closest('turbo-frame[data-turbo-frame-src]') ||
+    element.closest('turbo-frame')
+  )
 }
 
 function assignElementValueToPayload (element, payload = {}) {
@@ -48,5 +51,5 @@ function buildAttributePayload (element) {
 export default {
   buildAttributePayload,
   findClosestCommand,
-  findClosestFrame
+  findClosestFrameWithSource
 }


### PR DESCRIPTION
if no enclosing `turbo-frame` with a `src` is found, fall back to the original algorithm

closes #78 