### PR TITLE
Fix Ruby syntax error

### DIFF
--- a/lib/turbo_boost/commands/patches/action_view_helpers_tag_helper_tag_builder_patch.rb
+++ b/lib/turbo_boost/commands/patches/action_view_helpers_tag_helper_tag_builder_patch.rb
@@ -3,8 +3,8 @@
 require_relative "../attribute_hydration"
 
 module TurboBoost::Commands::Patches::ActionViewHelpersTagHelperTagBuilderPatch
-  def tag_options(options, ...)
+  def tag_options(options, *args, **kwargs, &block)
     dehydrated_options = TurboBoost::Commands::AttributeHydration.dehydrate(options)
-    super(dehydrated_options, ...)
+    super(dehydrated_options, *args, **kwargs, &block)
   end
 end


### PR DESCRIPTION
## Summary
This fixes this syntax error:
```
syntax error, unexpected (... (SyntaxError)
  def tag_options(options, ...)
                           ^~~
syntax error, unexpected ')'
... super(dehydrated_options, ...)                           ^
```
Note: This error was triggered with Ruby 2.7.2
