### PR TITLE
Make message verifier url safe

### DIFF
--- a/lib/turbo_boost/commands/runner.rb
+++ b/lib/turbo_boost/commands/runner.rb
@@ -169,7 +169,7 @@ class TurboBoost::Commands::Runner
   end
 
   def message_verifier
-    ActiveSupport::MessageVerifier.new Rails.application.secret_key_base, digest: "SHA256"
+    ActiveSupport::MessageVerifier.new Rails.application.secret_key_base, digest: "SHA256", url_safe: true
   end
 
   # Same implementation as ActionController::Base but with public visibility


### PR DESCRIPTION
Since IIUC signed params are sometimes passed in a GET url, I thought making them [url safe](https://api.rubyonrails.org/classes/ActiveSupport/MessageVerifier.html#method-c-new) would be a good idea.