### PR TITLE
fix(js): allow pinning importmaps with gem

### DIFF
--- a/lib/turbo_boost/commands/engine.rb
+++ b/lib/turbo_boost/commands/engine.rb
@@ -26,6 +26,8 @@ module TurboBoost::Commands
     config.turbo_boost_commands[:apply_client_state_overrides] = false
     config.turbo_boost_commands[:apply_server_state_overrides] = false
 
+    config.turbo_boost_commands.precompile_assets = true
+
     initializer "turbo_boost_commands.configuration" do
       Mime::Type.register "text/vnd.turbo-boost.html", :turbo_boost
 
@@ -38,6 +40,14 @@ module TurboBoost::Commands
       ActiveSupport.on_load :action_view do
         # `self` is ActionView::Base
         ActionView::Helpers::TagHelper::TagBuilder.prepend TurboBoost::Commands::Patches::ActionViewHelpersTagHelperTagBuilderPatch
+      end
+    end
+
+    initializer "turbo_boost_commands.asset" do
+      config.after_initialize do |app|
+        if app.config.respond_to?(:assets) && app.config.turbo_boost_commands.precompile_assets
+          app.config.assets.precompile += %w[@turbo-boost/commands.js]
+        end
       end
     end
   end


### PR DESCRIPTION
Since import maps JSPM and the javascript ecosystem are a mess in their current state, allow import maps to match the assets served by the gem rather than download them from JSPM.

```ruby
pin "@turbo-boost/streams", to: "@turbo-boost/streams.js", preload: false
pin "@turbo-boost/commands", to: "@turbo-boost/commands.js", preload: false
pin "@turbo-boost/elements", to: "@turbo-boost/elements.js", preload: false
pin "alpinejs", preload: false # @3.13.5
pin "@alpinejs/morph", to: "@alpinejs--morph.js", preload: false # @3.13.5
```

That fixes that problem; I'm happy with this solution for now; seems fair since JSPM never updates. Perhaps we can update the documentation for importmaps to the following:

1. https://github.com/hopsoft/turbo_boost-streams/pull/51
2. https://github.com/hopsoft/turbo_boost-commands/pull/122
3. https://github.com/hopsoft/turbo_boost-elements/pull/49

This is verified to be working with: 

```ruby
gem "turbo_boost-streams",  github: "mhenrixon/turbo_boost-streams"
gem "turbo_boost-commands", github: "mhenrixon/turbo_boost-commands"
gem "turbo_boost-elements", github: "mhenrixon/turbo_boost-elements"
```